### PR TITLE
[Feat] 카카오맵 API 사용한 장소 목록 조회

### DIFF
--- a/src/main/java/com/pinup/controller/PlaceController.java
+++ b/src/main/java/com/pinup/controller/PlaceController.java
@@ -1,11 +1,11 @@
 package com.pinup.controller;
 
 import com.pinup.dto.response.PlaceDetailDto;
-import com.pinup.dto.response.PlaceSimpleDto;
 import com.pinup.dto.response.PlaceResponse;
+import com.pinup.dto.response.PlaceSimpleDto;
+import com.pinup.global.response.ApiSuccessResponse;
 import com.pinup.global.response.ResultResponse;
 import com.pinup.service.PlaceService;
-import com.pinup.global.response.ApiSuccessResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,8 +15,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
-import static com.pinup.global.response.ResultCode.*;
+import static com.pinup.global.response.ResultCode.GET_PLACES_SUCCESS;
+import static com.pinup.global.response.ResultCode.GET_PLACE_DETAIL_SUCCESS;
 
 @RestController
 @RequestMapping("/api/places")
@@ -38,13 +40,16 @@ public class PlaceController {
             @RequestParam(value = "radius", defaultValue = "1000") int radius,
             @RequestParam(value = "sort", defaultValue = "distance") String sort
     ) {
-       List<PlaceResponse> result = placeService.searchPlaces(category, query, longitude, latitude, radius, sort);
+        List<PlaceResponse> result = placeService.searchPlaces(category, query, longitude, latitude, radius, sort);
 
-       return ResponseEntity
-               .status(HttpStatus.OK)
-               .body(ApiSuccessResponse.from(result));
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiSuccessResponse.from(result));
     }
 
+    /**
+     * DB에 저장된(리뷰가 있는) 가게 목록만 페이징으로 조회
+     */
     @GetMapping
     public ResponseEntity<ResultResponse> getPlacePage(@RequestParam(value = "latitude") double latitude,
                                                        @RequestParam(value = "longitude") double longitude,
@@ -61,5 +66,22 @@ public class PlaceController {
         PlaceDetailDto result = placeService.getPlaceDetail(placeId);
 
         return ResponseEntity.ok(ResultResponse.of(GET_PLACE_DETAIL_SUCCESS, result));
+    }
+
+    @GetMapping("/keyword")
+    public ResponseEntity<ResultResponse> getPlacePageByKeyword(
+            @RequestParam(value = "keyword") String keyword,
+            @RequestParam(value = "latitude") String latitude,
+            @RequestParam(value = "longitude") String longitude,
+            @RequestParam(value = "radius", defaultValue = "1000") int radius,
+            @RequestParam(value = "sort", defaultValue = "distance") String sort,
+            @PageableDefault Pageable pageable
+    ) {
+
+        Page<Map<String, Object>> result =
+                placeService.getPlacePageByKeyword(keyword, latitude, longitude, radius, sort, pageable);
+
+        return ResponseEntity.ok(ResultResponse.of(GET_PLACES_SUCCESS, result));
+
     }
 }

--- a/src/main/java/com/pinup/controller/PlaceController.java
+++ b/src/main/java/com/pinup/controller/PlaceController.java
@@ -73,7 +73,7 @@ public class PlaceController {
             @RequestParam(value = "keyword") String keyword,
             @RequestParam(value = "latitude") String latitude,
             @RequestParam(value = "longitude") String longitude,
-            @RequestParam(value = "radius", defaultValue = "1000") int radius,
+            @RequestParam(value = "radius", defaultValue = "20000") int radius,
             @RequestParam(value = "sort", defaultValue = "distance") String sort,
             @PageableDefault Pageable pageable
     ) {

--- a/src/main/java/com/pinup/global/maps/KakaoMapModule.java
+++ b/src/main/java/com/pinup/global/maps/KakaoMapModule.java
@@ -2,7 +2,6 @@ package com.pinup.global.maps;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.pinup.dto.response.PlaceReviewInfoDto;
 import com.pinup.entity.Member;
 import com.pinup.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,9 +24,9 @@ import java.util.Map;
 @Slf4j
 public class KakaoMapModule {
 
-    private static final String KAKAO_URI = "https://dapi.kakao.com";
-    private static final String CATEGORY_PATH = "/v2/local/search/category.json";
-    private static final String KEYWORD_PATH = "/v2/local/search/keyword.json";
+    private static final String KAKAO_MAP_API_URI = "https://dapi.kakao.com/v2/local/search";
+    private static final String CATEGORY_FORMAT = "/category.json";
+    private static final String KEYWORD_FORMAT = "/keyword.json";
     private static final String HEADER_KEY = "Authorization";
     private static final String HEADER_VALUE = "KakaoAK ";
 
@@ -38,14 +37,36 @@ public class KakaoMapModule {
     @Value("${kakao.key}")
     private String apiKey;
 
+    public List<Map<String, Object>> search(Member loginMember, String keyword, String latitude,
+                                            String longitude, int radius, String sort) {
+
+        URI kakaoSearchUri = buildUri(keyword, latitude, longitude, radius, sort);
+
+        return executeSearchRequest(kakaoSearchUri, loginMember);
+    }
+
+    private URI buildUri(String keyword, String latitude, String longitude, int radius, String sort) {
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder
+                .fromUriString(KAKAO_MAP_API_URI)
+                .path(KEYWORD_FORMAT)
+                .queryParam("query", keyword)
+                .queryParam("x", longitude)
+                .queryParam("y", latitude)
+                .queryParam("radius", radius)
+                .queryParam("sort", sort);
+
+        return uriBuilder.encode().build().toUri();
+    }
+
+
     public List<Map<String, Object>> searchPlaces(Member currentMember, String key, String value,
                                                   String longitude, String latitude, int radius, String sort) {
-
         String path;
         if (key.equals("category_group_code")) {
-            path = CATEGORY_PATH;
+            path = CATEGORY_FORMAT;
         } else {
-            path = KEYWORD_PATH;
+            path = KEYWORD_FORMAT;
         }
 
         URI uri = buildPlaceSearchUri(path, key, value, longitude, latitude, radius, sort);
@@ -83,21 +104,25 @@ public class KakaoMapModule {
     private Map<String, Object> extractPlaceInfo(JsonNode documentNode, Member currentMember) {
 
         Map<String, Object> placeInfo = new HashMap<>();
+
         String kakaoMapId = documentNode.path("id").asText();
+        Long reviewCount = placeRepository.getReviewCount(currentMember, kakaoMapId);
 
         // PinUP DB에서 가져온 리뷰 데이터
-        PlaceReviewInfoDto placeReviewInfo = placeRepository.findPlaceReviewInfo(kakaoMapId, currentMember);
+//        PlaceReviewInfoDto placeReviewInfo = placeRepository.findPlaceReviewInfo(kakaoMapId, currentMember);
 
         placeInfo.put("kakaoMapId", kakaoMapId);
         placeInfo.put("name", documentNode.path("place_name").asText());
         placeInfo.put("category", documentNode.path("category_group_name").asText());
-        placeInfo.put("phone", documentNode.path("phone").asText());
+        // placeInfo.put("phone", documentNode.path("phone").asText());
         placeInfo.put("address", documentNode.path("address_name").asText());
-        placeInfo.put("roadAddress", documentNode.path("road_address_name").asText());
-        placeInfo.put("longitudeX", documentNode.path("x").asText());
-        placeInfo.put("latitudeY", documentNode.path("y").asText());
-        placeInfo.put("distance", documentNode.path("distance").asText());
-        placeInfo.put("reviewData", placeReviewInfo);
+         placeInfo.put("roadAddress", documentNode.path("road_address_name").asText());
+         placeInfo.put("longitudeX", documentNode.path("x").asText());
+         placeInfo.put("latitudeY", documentNode.path("y").asText());
+         placeInfo.put("reviewCount", reviewCount);
+
+//        placeInfo.put("distance", documentNode.path("distance").asText());
+//        placeInfo.put("reviewData", placeReviewInfo);
 
         return placeInfo;
     }
@@ -106,7 +131,7 @@ public class KakaoMapModule {
                                     String longitude, String latitude, int radius, String sort) {
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder
-                .fromUriString(KAKAO_URI)
+                .fromUriString(KAKAO_MAP_API_URI)
                 .path(path)
                 .queryParam(key, value)
                 .queryParam("x", longitude)

--- a/src/main/java/com/pinup/repository/querydsl/PlaceRepositoryQueryDsl.java
+++ b/src/main/java/com/pinup/repository/querydsl/PlaceRepositoryQueryDsl.java
@@ -19,4 +19,6 @@ public interface PlaceRepositoryQueryDsl {
             Member loginMember,
             Long placeId
     );
+
+    Long getReviewCount(Member loginMember, String kakaoMapId);
 }

--- a/src/main/java/com/pinup/repository/querydsl/PlaceRepositoryQueryDslImpl.java
+++ b/src/main/java/com/pinup/repository/querydsl/PlaceRepositoryQueryDslImpl.java
@@ -174,6 +174,19 @@ public class PlaceRepositoryQueryDslImpl implements PlaceRepositoryQueryDsl{
         return placeDetailDto;
     }
 
+    @Override
+    public Long getReviewCount(Member loginMember, String kakaoMapId) {
+        return queryFactory
+                .select(review.count())
+                .from(review)
+                .where(review.place.kakaoMapId.eq(kakaoMapId)
+                        .and(review.member.id.eq(loginMember.getId())
+                                .or(review.member.id.in(getFriendMemberIds(loginMember.getId())))
+                        )
+                )
+                .fetchOne();
+    }
+
     private NumberTemplate<Double> calculateDistance(double latitude1, double longitude1, StringPath latitude2, StringPath longitude2) {
         return Expressions.numberTemplate(Double.class,
                 "6371 * acos(cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) + sin(radians({4})) * sin(radians({5})))",


### PR DESCRIPTION
## #️⃣연관된 이슈
* #13 

## 📝작업한 내용
1. 검색어를 입력 후 장소 목록 조회 시 카카오맵 API 사용
2. 장소 정보와 해당 장소에 대한 리뷰 개수 출력

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 기능 추가