### PR TITLE
[Fix] 랜딩페이지 지도탭 가게 목록 조회 기능 수정(#37)

### DIFF
--- a/src/main/java/com/pinup/controller/PlaceController.java
+++ b/src/main/java/com/pinup/controller/PlaceController.java
@@ -22,7 +22,7 @@ import static com.pinup.global.response.ResultCode.GET_PLACE_DETAIL_SUCCESS;
 
 @RestController
 @RequestMapping("/api/places")
-@Tag(name = "장소 API", description = "키워드 없이 장소 목록 조회, 키워드로 장소 목록 조회, 장소 상세 조회")
+@Tag(name = "장소 API", description = "장소 목록 조회(리뷰있는 가게만), 장소 목록 조회(전체) 장소 상세 조회")
 public class PlaceController {
 
     private final PlaceService placeService;
@@ -34,8 +34,8 @@ public class PlaceController {
 
     @GetMapping
     @Operation(
-            summary = "키워드 없이 장소 목록 조회 API",
-            description = "리뷰가 있는 장소 목록만 조회 / 카테고리(음식점, 카페), 정렬조건(가까운 순, 최신 순, 별점 높은 순, 별점 낮은 순)"
+            summary = "리뷰 있는 장소 목록 조회 API",
+            description = "리뷰 있는 장소 목록만 조회(랜딩 페이지에서 사용)"
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -47,32 +47,35 @@ public class PlaceController {
             )
     })
     public ResponseEntity<ResultResponse> getPlaces(
-            @Schema(description = "카테고리", example = "카페")
-            @RequestParam(defaultValue = "전체", value = "category", required = false) String category,
+            @Schema(description = "키워드", example = "스타벅스")
+            @RequestParam(defaultValue = "", value = "query", required = false) String query,
 
-            @Schema(description = "정렬조건", example = "가까운 순")
-            @RequestParam(defaultValue = "가까운 순", value = "sort", required = false) String sort,
+            @Schema(description = "카테고리", example = "ALL")
+            @RequestParam(defaultValue = "ALL", value = "category", required = false) String category,
 
-            @Schema(description = "SW 위도", example = "37.600720")
+            @Schema(description = "정렬조건", example = "NEAR")
+            @RequestParam(defaultValue = "NEAR", value = "sort", required = false) String sort,
+
+            @Schema(description = "SW 위도", example = "37.548608")
             @RequestParam(value = "swLatitude") double swLatitude,
 
-            @Schema(description = "SW 경도", example = "127.013901")
+            @Schema(description = "SW 경도", example = "126.795968")
             @RequestParam(value = "swLongitude") double swLongitude,
 
-            @Schema(description = "NE 위도", example = "37.613230")
+            @Schema(description = "NE 위도", example = "37.569940")
             @RequestParam(value = "neLatitude") double neLatitude,
 
-            @Schema(description = "NE 경도", example = "127.030003")
+            @Schema(description = "NE 경도", example = "126.844764")
             @RequestParam(value = "neLongitude") double neLongitude,
 
-            @Schema(description = "현 위치 위도(집)", example = "37.607798")
+            @Schema(description = "현 위치 위도(회사)", example = "37.562651")
             @RequestParam(value = "currentLatitude") double currentLatitude,
 
-            @Schema(description = "현 위치 경도(집)", example = "127.025612")
+            @Schema(description = "현 위치 경도(회사)", example = "126.826539")
             @RequestParam(value = "currentLongitude") double currentLongitude
     ) {
         List<PlaceResponseWithFriendReview> result = placeService.getPlaces(
-                category, sort, swLatitude, swLongitude, neLatitude, neLongitude, currentLatitude, currentLongitude
+                query, category, sort, swLatitude, swLongitude, neLatitude, neLongitude, currentLatitude, currentLongitude
         );
         return ResponseEntity.ok(ResultResponse.of(GET_PLACES_SUCCESS, result));
     }
@@ -97,7 +100,7 @@ public class PlaceController {
     }
 
     @GetMapping("/keyword")
-    @Operation(summary = "키워드로 장소 목록 조회 API", description = "리뷰 작성 시 장소 목록 조회할 때 사용 / 카카오맵 API 호출함")
+    @Operation(summary = "전체 장소 목록 조회 API", description = "리뷰 작성할 장소 조회 시 사용 / 카카오맵 API 호출")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",

--- a/src/main/java/com/pinup/dto/request/PlaceRequest.java
+++ b/src/main/java/com/pinup/dto/request/PlaceRequest.java
@@ -23,7 +23,7 @@ public class PlaceRequest {
     @NotBlank(message = "장소명을 입력하세요.")
     private String name; // 장소명
 
-    @Schema(description = "카테고리", example = "카페")
+    @Schema(description = "카테고리", example = "CAFE")
     @NotBlank(message = "카테고리를 입력하세요.")
     private String category; // 장소 카테고리
 
@@ -43,7 +43,7 @@ public class PlaceRequest {
 
     public Place toEntity() {
 
-        PlaceCategory placeCategory = PlaceCategory.getCategoryByDescription(category);
+        PlaceCategory placeCategory = PlaceCategory.getCategory(category);
 
         return Place.builder()
                 .kakaoMapId(kakaoPlaceId)

--- a/src/main/java/com/pinup/enums/PlaceCategory.java
+++ b/src/main/java/com/pinup/enums/PlaceCategory.java
@@ -1,5 +1,7 @@
 package com.pinup.enums;
 
+import com.pinup.global.exception.EntityNotFoundException;
+import com.pinup.global.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -16,12 +18,12 @@ public enum PlaceCategory {
     private final String description;
     private final String code;
 
-    public static PlaceCategory getCategoryByDescription(String category) {
+    public static PlaceCategory getCategory(String category) {
         for (PlaceCategory placeCategory : PlaceCategory.values()) {
-            if (placeCategory.description.equals(category)) {
+            if (placeCategory.name().equalsIgnoreCase(category)) {
                 return placeCategory;
             }
         }
-        return null;
+        throw new EntityNotFoundException(ErrorCode.PLACE_CATEGORY_NOT_FOUND);
     }
 }

--- a/src/main/java/com/pinup/enums/SortType.java
+++ b/src/main/java/com/pinup/enums/SortType.java
@@ -1,5 +1,7 @@
 package com.pinup.enums;
 
+import com.pinup.global.exception.EntityNotFoundException;
+import com.pinup.global.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -16,13 +18,13 @@ public enum SortType {
 
     private final String description;
 
-    public static SortType getSortTypeByDescription(String sortDescription) {
+    public static SortType getSortType(String sort) {
         for (SortType sortType : SortType.values()) {
-            if (sortType.description.equals(sortDescription)) {
+            if (sortType.name().equalsIgnoreCase(sort)) {
                 return sortType;
             }
         }
-        return null;
+        throw new EntityNotFoundException(ErrorCode.PLACE_SORT_NOT_FOUND);
     }
 
 }

--- a/src/main/java/com/pinup/global/exception/ErrorCode.java
+++ b/src/main/java/com/pinup/global/exception/ErrorCode.java
@@ -49,6 +49,8 @@ public enum ErrorCode {
 
     // Place
     PLACE_NOT_FOUND(404, "P001", "존재하지 않는 장소입니다."),
+    PLACE_CATEGORY_NOT_FOUND(404, "P002", "존재하지 않는 장소 카테고리입니다."),
+    PLACE_SORT_NOT_FOUND(404, "P003", "존재하지 않는 장소 정렬 필터입니다."),
 
     // Friend
     ALREADY_EXIST_FRIEND_REQUEST(400, "F001", "이미 존재하는 친구 요청입니다."),

--- a/src/main/java/com/pinup/repository/querydsl/PlaceRepositoryQueryDsl.java
+++ b/src/main/java/com/pinup/repository/querydsl/PlaceRepositoryQueryDsl.java
@@ -12,6 +12,7 @@ public interface PlaceRepositoryQueryDsl {
 
     List<PlaceResponseWithFriendReview> findAllByMemberAndLocation(
             Member loginMember,
+            String query,
             PlaceCategory category,
             SortType sortType,
             double swLatitude,

--- a/src/main/java/com/pinup/repository/querydsl/PlaceRepositoryQueryDslImpl.java
+++ b/src/main/java/com/pinup/repository/querydsl/PlaceRepositoryQueryDslImpl.java
@@ -35,7 +35,7 @@ public class PlaceRepositoryQueryDslImpl implements PlaceRepositoryQueryDsl{
 
     @Override
     public List<PlaceResponseWithFriendReview> findAllByMemberAndLocation(
-            Member loginMember, PlaceCategory placeCategory, SortType sortType,
+            Member loginMember, String query, PlaceCategory placeCategory, SortType sortType,
             double swLatitude, double swLongitude, double neLatitude,
             double neLongitude, double currentLatitude, double currentLongitude
     ) {
@@ -61,6 +61,7 @@ public class PlaceRepositoryQueryDslImpl implements PlaceRepositoryQueryDsl{
                         .and(place.latitude.between(swLatitude, neLatitude))
                         .and(place.longitude.between(swLongitude, neLongitude))
                         .and(searchByPlaceCategory(placeCategory))
+                        .and(searchByQuery(query))
                 )
                 .groupBy(place)
                 .orderBy(searchBySortType(sortType, currentLatitude, currentLongitude, place.latitude, place.longitude))
@@ -159,6 +160,10 @@ public class PlaceRepositoryQueryDslImpl implements PlaceRepositoryQueryDsl{
 
                 )
                 .fetchOne();
+    }
+
+    private BooleanExpression searchByQuery(String query) {
+        return !query.isEmpty() ? place.name.containsIgnoreCase(query) : null;
     }
 
     private BooleanExpression searchByPlaceCategory(PlaceCategory placeCategory) {

--- a/src/main/java/com/pinup/service/PlaceService.java
+++ b/src/main/java/com/pinup/service/PlaceService.java
@@ -6,9 +6,6 @@ import com.pinup.dto.response.PlaceResponseWithFriendReview;
 import com.pinup.entity.Member;
 import com.pinup.enums.PlaceCategory;
 import com.pinup.enums.SortType;
-import com.pinup.global.exception.EntityAlreadyExistException;
-import com.pinup.global.exception.EntityNotFoundException;
-import com.pinup.global.exception.ErrorCode;
 import com.pinup.global.maps.KakaoMapModule;
 import com.pinup.global.util.AuthUtil;
 import com.pinup.repository.PlaceRepository;
@@ -30,17 +27,17 @@ public class PlaceService {
 
     @Transactional
     public List<PlaceResponseWithFriendReview> getPlaces(
-            String category, String sort, double swLatitude,
+            String query, String category, String sort, double swLatitude,
             double swLongitude, double neLatitude, double neLongitude,
             double currentLatitude, double currentLongitude
     ) {
         Member loginMember = authUtil.getLoginMember();
 
-        PlaceCategory placeCategory = PlaceCategory.getCategoryByDescription(category);
-        SortType sortType = SortType.getSortTypeByDescription(sort);
+        PlaceCategory placeCategory = PlaceCategory.getCategory(category);
+        SortType sortType = SortType.getSortType(sort);
 
         return placeRepository.findAllByMemberAndLocation(
-                loginMember, placeCategory, sortType,
+                loginMember, query, placeCategory, sortType,
                 swLatitude, swLongitude, neLatitude,
                 neLongitude, currentLatitude, currentLongitude
         );


### PR DESCRIPTION
## #️⃣연관된 이슈
* #37 

## 📝작업한 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. 랜딩 페이지에서 친구 리뷰 있는 가게만 표시
2. 카테고리, 정렬 기준 영어로 받아서 처리
  - 키워드로 조회할 수 있도록 가게 목록 조회 API에 키워드 파라미터 추가
  - 쿼리 Where 조건에 키워드 입력 여부에 따른 조건절 추가
  - 카테고리 및 필터 정렬 Enum 클래스 name으로 대소문자 구분 없이 비교하는 로직으로 수정
  - 전달 받은 카테고리 및 필터 정렬이 존재하지 않을 경우 예외 처리

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가
- [x] 리팩토링 (기능 변경 X)