### PR TITLE
25.1.26(일) 회의 내용 반영 (with 석우님)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-	implementation 'org.springframework.kafka:spring-kafka'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pinup/controller/ReviewController.java
+++ b/src/main/java/com/pinup/controller/ReviewController.java
@@ -38,8 +38,8 @@ public class ReviewController {
             @Valid @RequestPart PlaceRequest placeRequest,
             @RequestPart(name = "multipartFiles", required = false) List<MultipartFile> multipartFiles
     ) {
-        Long reviewId = reviewService.register(reviewRequest, placeRequest, multipartFiles);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.CREATE_REVIEW_SUCCESS, reviewId));
+        String kakaoPlaceId = reviewService.register(reviewRequest, placeRequest, multipartFiles);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.CREATE_REVIEW_SUCCESS, kakaoPlaceId));
     }
 
     @GetMapping("/{reviewId}")

--- a/src/main/java/com/pinup/global/config/SwaggerConfig.java
+++ b/src/main/java/com/pinup/global/config/SwaggerConfig.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Configuration;
 public class SwaggerConfig {
 
     private final String BEARER_TOKEN_PREFIX = "Bearer";
+
     @Bean
     public OpenAPI openAPI() {
         String securityJwtName = "JWT";

--- a/src/main/java/com/pinup/global/response/ResultCode.java
+++ b/src/main/java/com/pinup/global/response/ResultCode.java
@@ -38,8 +38,6 @@ public enum ResultCode {
     GET_MEMBER_PHOTO_REVIEW_PREVIEW_SUCCESS(200, "R006", "멤버의 포토 리뷰 미리보기 목록 조회에 성공하였습니다."),
     GET_MEMBER_TEXT_REVIEW_SUCCESS(200, "R007", "멤버의 텍스트 리뷰 목록 조회에 성공하였습니다."),
 
-
-
     // Friend
     REQUEST_PIN_BUDDY_SUCCESS(201, "F001", "핀버디 신청이 완료되었습니다."),
     ACCEPT_PIN_BUDDY_SUCCESS(200, "F002", "핀버디 신청을 수락했습니다."),

--- a/src/main/java/com/pinup/service/ReviewService.java
+++ b/src/main/java/com/pinup/service/ReviewService.java
@@ -44,16 +44,15 @@ public class ReviewService {
     private final S3Service s3Service;
 
     @Transactional
-    public Long register(ReviewRequest reviewRequest, PlaceRequest placeRequest, List<MultipartFile> images) {
+    public String register(ReviewRequest reviewRequest, PlaceRequest placeRequest, List<MultipartFile> images) {
         Member loginMember = authUtil.getLoginMember();
         Place place = findOrCreatePlace(placeRequest);
         List<String> uploadedFileUrls = uploadImages(images);
-
         Review newReview = createReview(reviewRequest, loginMember, place, uploadedFileUrls);
         newReview.setType(images != null && !images.isEmpty() ? ReviewType.PHOTO : ReviewType.TEXT);
+        reviewRepository.save(newReview);
 
-        Review savedReview = reviewRepository.save(newReview);
-        return savedReview.getId();
+        return place.getKakaoMapId();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣연관된 이슈
* #39 

## 📝작업한 내용
1. 리뷰 등록 성공 후 응답 데이터를 reviewId -> kakaoPlaceId로 요청
  - 리뷰 등록 후 장소 상세 조회 페이지로 이동하기 위함)
2. 카카오맵 API를 통해 수집한 장소 데이터 필터링
  -  리뷰 등록 시 카테고리가 음식점, 카페인 장소만 DB에 등록하므로, 카테고리가 음식점, 카페인 장소만 반환

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가
- [x] 리팩토링 (기능 변경 X)
- [x] 문서 내용 수정