### PR TITLE
[Fix] 토큰 재발급 & 로그아웃 로직 수정

### DIFF
--- a/src/main/java/com/pinup/domain/member/controller/AuthController.java
+++ b/src/main/java/com/pinup/domain/member/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.pinup.domain.member.controller;
 
-
 import com.pinup.domain.member.dto.request.LoginRequest;
 import com.pinup.domain.member.dto.request.SignUpRequest;
 import com.pinup.domain.member.dto.response.LoginResponse;
@@ -64,7 +63,7 @@ public class AuthController {
     @Operation(summary = "토큰 재발급 API", description = "헤더에 refreshToken 필요")
     @ApiResponse(content = {@Content(schema = @Schema(implementation = LoginResponse.class))})
     @PostMapping("/refresh")
-    public ResponseEntity<ResultResponse> refresh(@RequestHeader("Authorization") String refreshToken) {
+    public ResponseEntity<ResultResponse> refresh(@RequestHeader("Refresh") String refreshToken) {
         return ResponseEntity.ok(ResultResponse.of(
                 ResultCode.TOKEN_REISSUED_SUCCESS, authService.refresh(refreshToken))
         );

--- a/src/main/java/com/pinup/domain/member/exception/ExpiredTokenException.java
+++ b/src/main/java/com/pinup/domain/member/exception/ExpiredTokenException.java
@@ -1,0 +1,11 @@
+package com.pinup.domain.member.exception;
+
+import com.pinup.global.exception.BusinessException;
+import com.pinup.global.response.ErrorCode;
+
+public class ExpiredTokenException extends BusinessException {
+
+    public ExpiredTokenException() {
+        super(ErrorCode.EXPIRED_TOKEN);
+    }
+}

--- a/src/main/java/com/pinup/global/config/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/pinup/global/config/jwt/JwtTokenFilter.java
@@ -1,11 +1,17 @@
 package com.pinup.global.config.jwt;
 
 
-import com.pinup.global.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pinup.global.response.ErrorCode;
+import com.pinup.global.response.ErrorResponse;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -13,6 +19,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 public class JwtTokenFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -24,17 +31,17 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String jwt = resolveToken(request);
         try {
+            String jwt = resolveToken(request);
             if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
                 Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
             filterChain.doFilter(request, response);
-        } catch (BusinessException e) {
-            response.sendError(e.getErrorCode().getStatus(), e.getMessage());
-        } catch (Exception e) {
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+        } catch (ExpiredJwtException e) {
+            setErrorResponse(response, ErrorCode.EXPIRED_TOKEN);
+        } catch (JwtException | IllegalArgumentException exception) {
+            setErrorResponse(response, ErrorCode.INVALID_TOKEN);
         } finally {
             SecurityContextHolder.clearContext();
         }
@@ -46,5 +53,16 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(errorCode)));
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/pinup/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/pinup/global/config/jwt/JwtTokenProvider.java
@@ -65,12 +65,8 @@ public class JwtTokenProvider {
     }
 
     public boolean validateToken(String token) {
-        try {
-            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return !claims.getBody().getExpiration().before(new Date());
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new InvalidTokenException();
-        }
+        Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        return !claims.getBody().getExpiration().before(new Date());
     }
 
     public String getSocialId(String token) {

--- a/src/main/java/com/pinup/global/response/ErrorCode.java
+++ b/src/main/java/com/pinup/global/response/ErrorCode.java
@@ -36,7 +36,7 @@ public enum ErrorCode {
     FORBIDDEN(403, "AU003", "접근할 수 있는 권한이 없습니다."),
     EXPIRED_OR_PREVIOUS_REFRESH_TOKEN(403, "AU004", "만료되었거나 이전에 발급된 Refresh Token입니다."),
     ACCESS_DENIED(401, "AU005", "유효한 인증 정보가 아닙니다."),
-    EXPIRED_ACCESS_TOKEN(401, "AU006", "Access Token이 만료되었습니다. 토큰을 재발급해주세요"),
+    EXPIRED_TOKEN(401, "AU006", "토큰 유효기간이 만료되었습니다."),
     LOGIN_TYPE_NOT_FOUND(400, "AU007", "일치하는 로그인 타입을 찾을 수 없습니다."),
 
     // Member


### PR DESCRIPTION
## 📝작업한 내용
1. Filter에서 예외 발생 시 DispatcherServlet으로 넘어오지 않기 때문에, GlobalExceptionHandler 적용이 되지 않음
2. Filter 자체에서 에러 커스텀해서 반환하도록 변경
3. 토큰 유효기간 만료 및 토큰 값에 이상이 있을 경우를 구분해서 예외 처리 적용

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가
- [x] 리팩토링 (기능 변경 X)