### PR TITLE
[Fix] 장소 상세 조회 시 동일 리뷰가 리뷰 이미지 개수만큼 조회되는 버그 조치

### DIFF
--- a/src/main/java/com/pinup/domain/place/repository/querydsl/PlaceRepositoryQueryDslImpl.java
+++ b/src/main/java/com/pinup/domain/place/repository/querydsl/PlaceRepositoryQueryDslImpl.java
@@ -105,7 +105,7 @@ public class PlaceRepositoryQueryDslImpl implements PlaceRepositoryQueryDsl{
     public List<ReviewDetailResponse> findAllTargetMemberReviews(Long memberId, String kakaoPlaceId) {
         List<Long> targetMemberIds = fetchTargetMemberIds(memberId);
         List<ReviewDetailResponse> reviewDetails = queryFactory
-                .select(Projections.constructor(ReviewDetailResponse.class,
+                .selectDistinct(Projections.constructor(ReviewDetailResponse.class,
                         review.id.as("reviewId"),
                         review.member.nickname.as("writerName"),
                         review.member.reviews.size().as("writerTotalReviewCount"),


### PR DESCRIPTION
## 📝작업한 내용
select -> selectDistinct

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정