### PR TITLE
Cors 방지를 위해 헤더 허용 리스트에 Access 추가

### DIFF
--- a/src/main/java/com/pinup/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/pinup/global/config/security/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://fe-pin-up.vercel.app", "https://api.kwonyonghyun.p-e.kr"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowCredentials(true);
-        configuration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type", "Refresh"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type", "Access", "Refresh"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;


### PR DESCRIPTION
## 📝작업한 내용
> 로그아웃 시 Access 헤더에 Access Token을 넣어주어야 하므로, Cors 방지를 위해 헤더 허용 리스트에 Access 추가

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정