### PR TITLE
장소 API 리팩토링 & 장소 클러스터링 기능 도입

### DIFF
--- a/src/main/java/com/pinup/domain/member/controller/MemberController.java
+++ b/src/main/java/com/pinup/domain/member/controller/MemberController.java
@@ -79,8 +79,12 @@ public class MemberController {
     @GetMapping("/{memberId}/text-reviews")
     public ResponseEntity<ResultResponse> getTextReviews(
             @PathVariable Long memberId,
-            @RequestParam int page,
-            @RequestParam int size
+
+            @Schema(description = "현재 페이지", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Schema(description = "한 페이지에 노출할 데이터 건수", example = "20")
+            @RequestParam(defaultValue = "20") int size
     ) {
         Pageable pageable = PageRequest.of(page, size);
 
@@ -95,8 +99,12 @@ public class MemberController {
     @GetMapping("/{memberId}/photo-reviews")
     public ResponseEntity<ResultResponse> getPhotoReviews(
             @PathVariable Long memberId,
-            @RequestParam int page,
-            @RequestParam int size
+
+            @Schema(description = "현재 페이지", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Schema(description = "한 페이지에 노출할 데이터 건수", example = "20")
+            @RequestParam(defaultValue = "20") int size
     ) {
         Pageable pageable = PageRequest.of(page, size);
 

--- a/src/main/java/com/pinup/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/pinup/domain/place/controller/PlaceController.java
@@ -104,7 +104,63 @@ public class PlaceController {
     public ResponseEntity<ResultResponse> getEntirePlaces(
             @Schema(description = "검색어", example = "하루카페") @RequestParam(value = "query") String query
     ) {
-        List<EntirePlaceResponse> result = placeService.getEntirePlaces(query);
+        List<PlaceResponse> result = placeService.getEntirePlaces(query);
+        return ResponseEntity.ok(ResultResponse.of(GET_PLACES_SUCCESS, result));
+    }
+
+    @Operation(summary = "지도 상 장소 목록 조회 API", description = "클러스터링 적용")
+    @ApiResponse(content = {@Content(schema = @Schema(implementation = TotalPlaceResponse.class))})
+    @GetMapping("/clustered")
+    public ResponseEntity<ResultResponse> getClusteredMapPlacesWithinBounds(
+            @Schema(description = "키워드", example = "스타벅스")
+            @RequestParam(defaultValue = "", value = "query", required = false) String query,
+
+            @Schema(description = "카테고리", example = "ALL")
+            @RequestParam(defaultValue = "ALL", value = "category", required = false) String category,
+
+            @Schema(description = "정렬조건", example = "NEAR")
+            @RequestParam(defaultValue = "NEAR", value = "sort", required = false) String sort,
+
+            @Schema(description = "지도 중심 위도", example = "37.3576046")
+            @RequestParam(value = "centerLatitude") double centerLatitude,
+
+            @Schema(description = "지도 중심 경도", example = "126.95550245")
+            @RequestParam(value = "centerLongitude") double centerLongitude,
+
+            @Schema(description = "SW 위도", example = "36.5258844")
+            @RequestParam(value = "swLatitude") double swLatitude,
+
+            @Schema(description = "SW 경도", example = "126.354001")
+            @RequestParam(value = "swLongitude") double swLongitude,
+
+            @Schema(description = "NE 위도", example = "38.1893248")
+            @RequestParam(value = "neLatitude") double neLatitude,
+
+            @Schema(description = "NE 경도", example = "127.5570039")
+            @RequestParam(value = "neLongitude") double neLongitude,
+
+            @Schema(description = "현 위치 위도", example = "37.5626316")
+            @RequestParam(value = "currentLatitude", required = false) Double currentLatitude,
+
+            @Schema(description = "현 위치 경도", example = "126.8357822")
+            @RequestParam(value = "currentLongitude", required = false) Double currentLongitude,
+
+            @Schema(description = "줌 레벨", example = "0")
+            @RequestParam(value = "zoomLevel") int zoomLevel
+    ) {
+        MapViewDto mapView = MapViewDto.builder()
+                .centerLat(centerLatitude)
+                .centerLng(centerLongitude)
+                .neLat(neLatitude)
+                .neLng(neLongitude)
+                .swLat(swLatitude)
+                .swLng(swLongitude)
+                .currLat(currentLatitude)
+                .currLng(currentLongitude)
+                .zoomLevel(zoomLevel + 1)
+                .build();
+        TotalPlaceResponse result = placeService.getClusteredMapPlacesWithinBounds(query, category, sort, mapView);
+
         return ResponseEntity.ok(ResultResponse.of(GET_PLACES_SUCCESS, result));
     }
 }

--- a/src/main/java/com/pinup/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/pinup/domain/place/controller/PlaceController.java
@@ -1,8 +1,8 @@
 package com.pinup.domain.place.controller;
 
-import com.pinup.domain.place.dto.response.EntirePlaceResponse;
-import com.pinup.domain.place.dto.response.MapPlaceDetailResponse;
-import com.pinup.domain.place.dto.response.MapPlaceResponse;
+import com.pinup.domain.place.dto.request.MapBoundDto;
+import com.pinup.domain.place.dto.request.MapViewDto;
+import com.pinup.domain.place.dto.response.*;
 import com.pinup.domain.place.service.PlaceService;
 import com.pinup.global.response.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,7 +34,7 @@ public class PlaceController {
     @Operation(summary = "리뷰 있는 장소 목록 조회 API")
     @ApiResponse(content = {@Content(schema = @Schema(implementation = MapPlaceResponse.class))})
     @GetMapping
-    public ResponseEntity<ResultResponse> getPlaces(
+    public ResponseEntity<ResultResponse> getMapPlaces(
             @Schema(description = "키워드", example = "스타벅스")
             @RequestParam(defaultValue = "", value = "query", required = false) String query,
 
@@ -61,17 +61,30 @@ public class PlaceController {
 
             @Schema(description = "현 위치 경도", example = "126.826539")
             @RequestParam(value = "currentLongitude", required = false) Double currentLongitude
+/*            @Schema(description = "현재 페이지", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Schema(description = "한 페이지에 노출할 데이터 건수", example = "20")
+            @RequestParam(defaultValue = "20") int size*/
     ) {
-        List<MapPlaceResponse> result = placeService.getMapPlaces(
-                query, category, sort, swLatitude, swLongitude, neLatitude, neLongitude, currentLatitude, currentLongitude
-        );
+//        Pageable pageable = PageRequest.of(page, size);
+        MapBoundDto mapBound = MapBoundDto.builder()
+                .neLat(neLatitude)
+                .neLng(neLongitude)
+                .swLat(swLatitude)
+                .swLng(swLongitude)
+                .currLat(currentLatitude)
+                .currLng(currentLongitude)
+                .build();
+        List<MapPlaceResponse> result = placeService.getMapPlaces(query, category, sort, mapBound);
+
         return ResponseEntity.ok(ResultResponse.of(GET_PLACES_SUCCESS, result));
     }
 
     @GetMapping("/{kakaoPlaceId}")
     @Operation(summary = "장소 상세 조회 API", description = "카카오맵에서 부여한 고유 ID로 장소 상세 조회")
     @ApiResponse(content = {@Content(schema = @Schema(implementation = MapPlaceDetailResponse.class))})
-    public ResponseEntity<ResultResponse> getPlaceDetail(
+    public ResponseEntity<ResultResponse> getMapPlaceDetail(
             @Schema(description = "카카오맵 장소 고유 ID", example = "1997608947")
             @PathVariable("kakaoPlaceId") String kakaoPlaceId,
 
@@ -86,9 +99,9 @@ public class PlaceController {
     }
 
     @Operation(summary = "전체 장소 목록 조회 API", description = "리뷰 작성할 장소 조회 시 사용 / 카카오맵 API 호출")
-    @ApiResponse(content = {@Content(schema = @Schema(implementation = EntirePlaceResponse.class))})
+    @ApiResponse(content = {@Content(schema = @Schema(implementation = PlaceResponse.class))})
     @GetMapping("/keyword")
-    public ResponseEntity<ResultResponse> getPlacesByKeyword(
+    public ResponseEntity<ResultResponse> getEntirePlaces(
             @Schema(description = "검색어", example = "하루카페") @RequestParam(value = "query") String query
     ) {
         List<EntirePlaceResponse> result = placeService.getEntirePlaces(query);

--- a/src/main/java/com/pinup/domain/place/dto/request/MapBoundDto.java
+++ b/src/main/java/com/pinup/domain/place/dto/request/MapBoundDto.java
@@ -1,0 +1,15 @@
+package com.pinup.domain.place.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MapBoundDto {
+    private Double neLat;
+    private Double neLng;
+    private Double swLat;
+    private Double swLng;
+    private Double currLat;
+    private Double currLng;
+}

--- a/src/main/java/com/pinup/domain/place/dto/request/MapViewDto.java
+++ b/src/main/java/com/pinup/domain/place/dto/request/MapViewDto.java
@@ -1,0 +1,18 @@
+package com.pinup.domain.place.dto.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MapViewDto {
+    private Double centerLat; // 지도 중심 위도
+    private Double centerLng; // 지도 중심 경도
+    private Double neLat;
+    private Double neLng;
+    private Double swLat;
+    private Double swLng;
+    private Double currLat;
+    private Double currLng;
+    private int zoomLevel; // 지도 줌 레벨
+}

--- a/src/main/java/com/pinup/domain/place/dto/response/PlaceClusterDto.java
+++ b/src/main/java/com/pinup/domain/place/dto/response/PlaceClusterDto.java
@@ -1,0 +1,16 @@
+package com.pinup.domain.place.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PlaceClusterDto {
+    private String clusterId; // 클러스터 또는 중심 장소 ID
+    private Double latitude;
+    private Double longitude;
+    private int count; // 클러스터 내 장소 갯수
+    private List<MapPlaceResponse> places; // 클러스터에 포함된 장소들
+}

--- a/src/main/java/com/pinup/domain/place/dto/response/PlaceResponse.java
+++ b/src/main/java/com/pinup/domain/place/dto/response/PlaceResponse.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Schema(title = "키워드로 장소 목록 조회 응답 DTO", description = "카카오맵 + 모든 장소 목록 조회")
-public class EntirePlaceResponse {
+public class PlaceResponse {
 
     @Schema(description = "카카오맵에서 부여한 장소 고유 ID")
     private String kakaoPlaceId;

--- a/src/main/java/com/pinup/domain/place/dto/response/TotalPlaceResponse.java
+++ b/src/main/java/com/pinup/domain/place/dto/response/TotalPlaceResponse.java
@@ -1,0 +1,13 @@
+package com.pinup.domain.place.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TotalPlaceResponse {
+    private List<PlaceClusterDto> clusters;
+    private List<MapPlaceResponse> places;
+}

--- a/src/main/java/com/pinup/domain/place/repository/querydsl/PlaceRepositoryQueryDsl.java
+++ b/src/main/java/com/pinup/domain/place/repository/querydsl/PlaceRepositoryQueryDsl.java
@@ -1,5 +1,6 @@
 package com.pinup.domain.place.repository.querydsl;
 
+import com.pinup.domain.place.dto.request.MapBoundDto;
 import com.pinup.domain.place.dto.response.MapPlaceResponse;
 import com.pinup.domain.place.entity.PlaceCategory;
 import com.pinup.domain.place.entity.SortType;
@@ -8,15 +9,8 @@ import com.pinup.domain.review.dto.response.ReviewDetailResponse;
 import java.util.List;
 
 public interface PlaceRepositoryQueryDsl {
-
-    List<MapPlaceResponse> findMapPlaces(
-            Long memberId, String query, PlaceCategory category, SortType sortType,
-            double swLatitude, double swLongitude, double neLatitude, double neLongitude,
-            Double currentLatitude, Double currentLongitude
-    );
-    MapPlaceResponse findMapPlaceDetail(
-            Long memberId, String kakaoPlaceId, Double currentLatitude, Double currentLongitude
-    );
+    List<MapPlaceResponse> findMapPlacesWithinBounds(Long memberId, String query, PlaceCategory category, SortType sortType, MapBoundDto mapBound);
+    MapPlaceResponse findMapPlaceDetail(Long memberId, String kakaoPlaceId, Double currentLatitude, Double currentLongitude);
     List<ReviewDetailResponse> findAllTargetMemberReviews(Long memberId, String kakaoPlaceId);
     Long getReviewCount(Long memberId, String kakaoPlaceId);
     Double getAverageStarRating(Long memberId, String kakaoPlaceId);

--- a/src/main/java/com/pinup/domain/place/service/PlaceClusteringService.java
+++ b/src/main/java/com/pinup/domain/place/service/PlaceClusteringService.java
@@ -1,0 +1,187 @@
+package com.pinup.domain.place.service;
+
+import com.pinup.domain.place.dto.request.MapViewDto;
+import com.pinup.domain.place.dto.response.MapPlaceResponse;
+import com.pinup.domain.place.dto.response.PlaceClusterDto;
+import com.pinup.domain.place.dto.response.TotalPlaceResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class PlaceClusteringService {
+
+    // 클러스터링을 위한 거리 임계값 (미터 단위)
+    private static final double BASE_CLUSTERING_DISTANCE = 100.0;
+
+    // 줌 레벨별 클러스터링 거리 조정 계수
+    private static final Map<Integer, Double> ZOOM_CLUSTERING_FACTORS = new HashMap<>();
+    private static final int EARTH_RADIUS_KM = 6371;
+
+    static {
+        // 줌 레벨별 클러스터링 거리 조정 계수 설정
+        // 숫자가 작을수록 거리가 커짐 (더 많은 장소가 클러스터링됨)
+        ZOOM_CLUSTERING_FACTORS.put(22, 0.05);  // 가장 확대 (건물 수준)
+        ZOOM_CLUSTERING_FACTORS.put(21, 0.1);
+        ZOOM_CLUSTERING_FACTORS.put(20, 0.2);
+        ZOOM_CLUSTERING_FACTORS.put(19, 0.3);
+        ZOOM_CLUSTERING_FACTORS.put(18, 0.5);   // 거리 수준
+        ZOOM_CLUSTERING_FACTORS.put(17, 0.8);
+        ZOOM_CLUSTERING_FACTORS.put(16, 1.0);   // 기본 거리
+        ZOOM_CLUSTERING_FACTORS.put(15, 1.5);
+        ZOOM_CLUSTERING_FACTORS.put(14, 2.0);   // 동네 수준
+        ZOOM_CLUSTERING_FACTORS.put(13, 3.0);
+        ZOOM_CLUSTERING_FACTORS.put(12, 5.0);   // 지구/구 수준
+        ZOOM_CLUSTERING_FACTORS.put(11, 8.0);
+        ZOOM_CLUSTERING_FACTORS.put(10, 12.0);  // 도시 수준
+        ZOOM_CLUSTERING_FACTORS.put(9, 20.0);
+        ZOOM_CLUSTERING_FACTORS.put(8, 30.0);   // 광역 수준
+        ZOOM_CLUSTERING_FACTORS.put(7, 50.0);
+        ZOOM_CLUSTERING_FACTORS.put(6, 80.0);   // 광역도/주 수준
+        ZOOM_CLUSTERING_FACTORS.put(5, 120.0);
+        ZOOM_CLUSTERING_FACTORS.put(4, 200.0);  // 국가 수준
+        ZOOM_CLUSTERING_FACTORS.put(3, 300.0);
+        ZOOM_CLUSTERING_FACTORS.put(2, 500.0);  // 대륙 수준
+        ZOOM_CLUSTERING_FACTORS.put(1, 1000.0); // 가장 축소
+    }
+
+    /**
+     * 줌 레벨에 따라 장소 리스트를 클러스터링하여 반환
+     * @param places 클러스터링할 장소 리스트
+     * @param mapView 지도 뷰 정보 (중심 좌표, 경계, 줌 레벨)
+     * @return 클러스터링된 결과
+     */
+    public TotalPlaceResponse clusterPlacesByZoomLevel(List<MapPlaceResponse> places, MapViewDto mapView) {
+        if (places.isEmpty()) {
+            return null;
+        }
+
+        // 줌 레벨에 따른 클러스터링 거리 계산
+        double clusteringDistance = calculateClusteringDistance(mapView.getZoomLevel());
+
+        // 장소를 지도 중심으로부터의 거리에 따라 정렬
+        List<MapPlaceResponse> sortedPlaces = sortPlacesByDistanceFromCenter(places, mapView.getCenterLat(), mapView.getCenterLng());
+
+        // 클러스터링 수행
+        return createClusters(sortedPlaces, clusteringDistance, mapView);
+    }
+
+    /**
+     * 정렬된 장소 목록에서 클러스터를 생성
+     */
+    private TotalPlaceResponse createClusters(List<MapPlaceResponse> sortedPlaces, double clusteringDistance, MapViewDto mapView) {
+        // 클러스터링 결과를 저장할 리스트
+        List<PlaceClusterDto> clusters = new ArrayList<>();
+
+        // 클러스터링 되지 않은 단일 장소를 저장할 리스트
+        List<MapPlaceResponse> places = new ArrayList<>();
+
+        // 처리된 장소의 kakaoPlaceId를 추적하기 위한 Set
+        Set<String> processedPlaceKakaoIds = new HashSet<>();
+
+        for (MapPlaceResponse place : sortedPlaces) {
+            // 이미 처리된 장소는 건너뜀
+            if (processedPlaceKakaoIds.contains(place.getKakaoPlaceId())) {
+                continue;
+            }
+
+            // 현재 장소 기준으로 근처 장소 찾기
+            List<MapPlaceResponse> nearbyPlaces = findNearbyPlaces(place, sortedPlaces, clusteringDistance, processedPlaceKakaoIds);
+
+            // 처리된 장소 목록에 추가
+            processedPlaceKakaoIds.add(place.getKakaoPlaceId());
+            if (nearbyPlaces.isEmpty()) {
+                places.add(place);
+                continue;
+            }
+            nearbyPlaces.forEach(nearbyPlace -> processedPlaceKakaoIds.add(nearbyPlace.getKakaoPlaceId()));
+
+            // 클러스터 생성 및 추가
+            clusters.add(createCluster(place, nearbyPlaces));
+        }
+
+        return new TotalPlaceResponse(clusters, places.stream()
+                .sorted(Comparator.comparingDouble(place ->
+                        calculateDistance(mapView.getCurrLat(), mapView.getCurrLng(), place.getLatitude(), place.getLongitude())))
+                .collect(Collectors.toList()));
+    }
+
+    private PlaceClusterDto createCluster(MapPlaceResponse centerPlace, List<MapPlaceResponse> nearbyPlaces) {
+
+        // 클러스터에 포함될 모든 장소
+        List<MapPlaceResponse> clusterPlaces = new ArrayList<>();
+        clusterPlaces.add(centerPlace);
+        clusterPlaces.addAll(nearbyPlaces);
+        // 클러스터의 중심좌표 계산
+        double avgLat = clusterPlaces.stream()
+                .mapToDouble(MapPlaceResponse::getLatitude)
+                .average()
+                .orElse(centerPlace.getLatitude());
+        double avgLng = clusterPlaces.stream()
+                .mapToDouble(MapPlaceResponse::getLongitude)
+                .average()
+                .orElse(centerPlace.getLongitude());
+
+        return PlaceClusterDto.builder()
+                .clusterId(centerPlace.getKakaoPlaceId())
+                .latitude(avgLat)
+                .longitude(avgLng)
+                .count(clusterPlaces.size())
+                .places(clusterPlaces)
+                .build();
+    }
+
+    private List<MapPlaceResponse> findNearbyPlaces(
+            MapPlaceResponse centerPlace, List<MapPlaceResponse> allPlaces,
+            double clusteringDistance, Set<String> processedKakaoPlaceIds
+    ) {
+        List<MapPlaceResponse> nearbyPlaces = new ArrayList<>();
+        for (MapPlaceResponse otherPlace : allPlaces) {
+            String otherId = otherPlace.getKakaoPlaceId();
+            // 자기 자신이거나 이미 처리된 장소는 제외
+            if (centerPlace.getKakaoPlaceId().equals(otherId) || processedKakaoPlaceIds.contains(otherId)) {
+                continue;
+            }
+            // 거리 계산하여 클러스터링 거리 이내인 경우 추가
+            double distance = calculateDistance(
+                    centerPlace.getLatitude(), centerPlace.getLongitude(),
+                    otherPlace.getLatitude(), otherPlace.getLongitude()
+            );
+            if (distance <= clusteringDistance) {
+                nearbyPlaces.add(otherPlace);
+            }
+        }
+
+        return nearbyPlaces;
+    }
+
+    private List<MapPlaceResponse> sortPlacesByDistanceFromCenter(List<MapPlaceResponse> places, Double centerLat, Double centerLng) {
+        return places.stream()
+                .sorted(Comparator.comparingDouble(place ->
+                        calculateDistance(centerLat, centerLng, place.getLatitude(), place.getLongitude())))
+                .collect(Collectors.toList());
+    }
+
+    private double calculateClusteringDistance(int zoomLevel) {
+        // 줌 레벨이 맵에 없으면 기본 거리 사용
+        double factor = ZOOM_CLUSTERING_FACTORS.getOrDefault(zoomLevel, 1.0);
+
+        return BASE_CLUSTERING_DISTANCE * factor;
+    }
+
+    /**
+     * 두 지점 간의 거리를 계산 (Haversine 공식 사용)
+     * @return 거리 (미터단위)
+     */
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lonDistance = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return EARTH_RADIUS_KM * c * 1000; // 미터 단위로 변환
+    }
+}

--- a/src/main/java/com/pinup/domain/place/service/PlaceService.java
+++ b/src/main/java/com/pinup/domain/place/service/PlaceService.java
@@ -1,9 +1,9 @@
 package com.pinup.domain.place.service;
 
 import com.pinup.domain.member.entity.Member;
-import com.pinup.domain.place.dto.response.MapPlaceDetailResponse;
-import com.pinup.domain.place.dto.response.MapPlaceResponse;
-import com.pinup.domain.place.dto.response.EntirePlaceResponse;
+import com.pinup.domain.place.dto.request.MapBoundDto;
+import com.pinup.domain.place.dto.request.MapViewDto;
+import com.pinup.domain.place.dto.response.*;
 import com.pinup.domain.place.entity.PlaceCategory;
 import com.pinup.domain.place.entity.SortType;
 import com.pinup.domain.place.repository.PlaceRepository;
@@ -27,20 +27,12 @@ public class PlaceService {
     private final PlaceRepository placeRepository;
 
     @Transactional(readOnly = true)
-    public List<MapPlaceResponse> getMapPlaces(
-            String query, String category, String sort,
-            double swLat, double swLon, double neLat,
-            double neLon, Double currLat, Double currLon
-    ) {
+    public List<MapPlaceResponse> getMapPlaces(String query, String category, String sort, MapBoundDto mapBound) {
         Member loginMember = authUtil.getLoginMember();
         PlaceCategory placeCategory = PlaceCategory.getCategory(category);
         SortType sortType = SortType.getSortType(sort);
 
-        return placeRepository.findMapPlaces(
-                loginMember.getId(), query, placeCategory, sortType,
-                swLat, swLon, neLat,
-                neLon, currLat, currLon
-        );
+        return placeRepository.findMapPlacesWithinBounds(loginMember.getId(), query, placeCategory, sortType, mapBound);
     }
 
     @Transactional(readOnly = true)
@@ -62,7 +54,7 @@ public class PlaceService {
     }
 
     @Transactional(readOnly = true)
-    public List<EntirePlaceResponse> getEntirePlaces(String keyword) {
+    public List<PlaceResponse> getEntirePlaces(String keyword) {
         Member loginMember = authUtil.getLoginMember();
 
         return kakaoMapModule.search(loginMember.getId(), keyword);

--- a/src/main/java/com/pinup/global/config/kakao/KakaoMapModule.java
+++ b/src/main/java/com/pinup/global/config/kakao/KakaoMapModule.java
@@ -2,7 +2,7 @@ package com.pinup.global.config.kakao;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.pinup.domain.place.dto.response.EntirePlaceResponse;
+import com.pinup.domain.place.dto.response.PlaceResponse;
 import com.pinup.domain.place.entity.PlaceCategory;
 import com.pinup.domain.place.repository.PlaceRepository;
 import com.pinup.global.common.Formatter;
@@ -36,7 +36,7 @@ public class KakaoMapModule {
     @Value("${kakao.key}")
     private String apiKey;
 
-    public List<EntirePlaceResponse> search(Long memberId, String keyword) {
+    public List<PlaceResponse> search(Long memberId, String keyword) {
         URI uri = buildUri(keyword);
         return executeSearchRequest(uri, memberId);
     }
@@ -50,8 +50,8 @@ public class KakaoMapModule {
         return uriBuilder.encode().build().toUri();
     }
 
-    private List<EntirePlaceResponse> executeSearchRequest(URI uri, Long memberId) {
-        List<EntirePlaceResponse> placeInfoList = new ArrayList<>();
+    private List<PlaceResponse> executeSearchRequest(URI uri, Long memberId) {
+        List<PlaceResponse> placeInfoList = new ArrayList<>();
         try {
             RequestEntity<Void> apiRequest = RequestEntity
                     .get(uri)
@@ -61,7 +61,7 @@ public class KakaoMapModule {
             JsonNode jsonNode = objectMapper.readTree(apiResponse.getBody());
             JsonNode documentsNode = jsonNode.path("documents");
             for (JsonNode documentNode : documentsNode) {
-                EntirePlaceResponse placeInfo = extractPlaceInfo(documentNode, memberId);
+                PlaceResponse placeInfo = extractPlaceInfo(documentNode, memberId);
                 placeInfoList.add(placeInfo);
             }
         } catch (Exception e) {
@@ -71,14 +71,14 @@ public class KakaoMapModule {
         return placeInfoList;
     }
 
-    private EntirePlaceResponse extractPlaceInfo(JsonNode documentNode, Long memberId) {
+    private PlaceResponse extractPlaceInfo(JsonNode documentNode, Long memberId) {
         String kakaoPlaceId = documentNode.path("id").asText();
         String categoryGroupCode = documentNode.path("category_group_code").asText();
         PlaceCategory placeCategory = PlaceCategory.getCategoryByCode(categoryGroupCode);
         Long reviewCount = placeRepository.getReviewCount(memberId, kakaoPlaceId);
         Double averageStarRating = placeRepository.getAverageStarRating(memberId, kakaoPlaceId);
 
-        return EntirePlaceResponse.builder()
+        return PlaceResponse.builder()
                 .kakaoPlaceId(kakaoPlaceId)
                 .name(documentNode.path("place_name").asText())
                 .placeCategory(placeCategory)


### PR DESCRIPTION
## 📝작업한 내용
* 위/경도 좌표 DTO로 묶기 & 클래스, 메서드명 변경
*  페이지네이션 적용한 컨트롤러에 스웨거 적용
    - 현재페이지(page): 0
    - 한 페이지에 노출할 데이터 건수(size): 20
* 줌 레벨에 따른 지도 상의 장소 클러스터링 기능 추가
  - 지도 중심 좌표 및 줌 레벨 필드 추가
  - 지도 중심좌표와 줌 레벨에 따라 장소가 클러스터링 거리 임계값(미터단위)보다 작거나 같으면 클러스터링에 포함시킴
  - 클러스터링 장소 리스트와 클러스터링에 포함되지 않는 장소 리스트 필드 분리하여 DTO 반환
  - 25.3.12 기획 회의 간 해당 기능은 추후 반영하는 것으로 결정

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 기능 추가
- [x] 리팩토링 (기능 변경 X)