### PR TITLE
[Fix] 유저 정보 수정 API 수정

### DIFF
--- a/src/main/java/com/pinup/domain/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/pinup/domain/member/dto/request/UpdateProfileRequest.java
@@ -11,7 +11,6 @@ public class UpdateProfileRequest {
     @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하로 입력해주세요.")
     private String nickname;
 
-    @NotBlank(message = "수정할 소개글을 입력해주세요.")
     @Size(max = 150, message = "소개글은 150자 이내로 입력해주세요.")
     private String bio;
 }

--- a/src/main/java/com/pinup/domain/member/service/MemberService.java
+++ b/src/main/java/com/pinup/domain/member/service/MemberService.java
@@ -93,10 +93,17 @@ public class MemberService {
     @Transactional
     public void updateProfile(UpdateProfileRequest updateProfileRequest, MultipartFile multipartFile) {
         Member loginMember = authUtil.getLoginMember();
+        String prevNickname = loginMember.getNickname();
+        String prevBio = loginMember.getBio();
         String newNickname = updateProfileRequest.getNickname();
-        validateNicknameUpdate(loginMember, newNickname);
-        loginMember.updateNickname(newNickname);
-        loginMember.updateBio(updateProfileRequest.getBio());
+        String newBio = updateProfileRequest.getBio();
+        if (!prevNickname.equals(newNickname)) {
+            validateNicknameUpdate(loginMember, newNickname);
+            loginMember.updateNickname(newNickname);
+        }
+        if (!prevBio.equals(newBio)) {
+            loginMember.updateBio(updateProfileRequest.getBio());
+        }
         String newProfileImageUrl = null;
         if (multipartFile != null && !multipartFile.isEmpty()) {
             s3Service.deleteFile(loginMember.getProfileImageUrl());
@@ -140,7 +147,6 @@ public class MemberService {
         return reviewPage.map(PhotoReviewResponse::from);
     }
 
-    @Transactional(readOnly = true)
     public boolean checkNicknameDuplicate(String nickname) {
         return memberRepository.existsByNickname(nickname);
     }


### PR DESCRIPTION
## 📝작업한 내용
* 기존 닉네임과 동일한 닉네임인 경우 중복여부 미검증
* 소개글 필수값 제거
* 기존 소개글과 동일한 소개글인 경우 업데이트 미실시

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정